### PR TITLE
Fixed several typos and grammar in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Harmony is a responsive jekyll theme. 
 
-- Build for jekyll 2.x
-- Support Google analytics and RSS feeds
+- Built for jekyll 2.x
+- Supports Google analytics and RSS feeds
 - Sass based styles
 - Browser support: IE 8+, Chrome, Safari and Firefox 
 - Fluidly responsive 
@@ -30,20 +30,20 @@ Harmony is a responsive jekyll theme.
 
 1. [Fork](https://github.com/web-create/harmony/fork) this repository.
 2. Clone it: git clone https://github.com/YOUR-USERNAME/harmony.
-3. If you completely new to jekyll, please read more about [Jekyll](http://jekyllrb.com/) and [Github pages](https://help.github.com/articles/using-jekyll-with-pages).
+3. If you're completely new to jekyll, please read more about [Jekyll](http://jekyllrb.com/) and [Github pages](https://help.github.com/articles/using-jekyll-with-pages).
 4. Change your directory into cloned repository. 
 5. Run `bundle install`
 6. Edit the _config.yml on root directory. Change `url` property to to 
 `http://127.0.0.1:4000` since you are going to run on localhost.
 7. Run the jekyll server by having: `jekyll serve --baseurl ''` or `rake preview`   
 
-Try to locate your browser at [http://localhost:4000](http://localhost:4000).
+Point your browser to [http://localhost:4000](http://localhost:4000).
 
-Note: If you are a windows user please refer this nice website - http://jekyll-windows.juthilo.com/ by Julian Thilo to configure ruby + jekyll on windows.
+Note: If you are a windows user please refer to this nice website - http://jekyll-windows.juthilo.com/ by Julian Thilo to configure ruby + jekyll on windows.
 
 ## Options/Usage
 
-Harmony theme has some customizable options. All the configuration details are 
+Harmony has some customizable options. All the configuration details are 
 configured in `_config.yml` file under root of the harmony directory. 
 
 Feel free to change your `name`, `descriptionn`, `meta_description`, `author details`,
@@ -91,8 +91,8 @@ Customize your footer links by editing `_includes/footer-links.html`
 
 #### Copyrights/Disclaimer statements
 
-All the copyrights notes are under `_includes/footer.html`. Also note that you 
-can toggle on/off copyright note from front-end by setting up `show_disclaimer` 
+All copyright notes are under `_includes/footer.html`. Also note that you 
+can toggle on/off copyright notes from the front-end by setting up `show_disclaimer` 
 property in `_config.yml`. 
 
 ### Screenshots


### PR DESCRIPTION
I fixed some spelling and grammatical errors in README.md to help it read more clearly.

Only text was changed, no links have been altered and nothing has been removed.

![screen shot 2015-07-04 at 4 39 21 pm](https://cloud.githubusercontent.com/assets/3507287/8509745/4d2dea58-226b-11e5-8795-30120923e468.png)
