### PR TITLE
Fix end div tag issue for multiple years in blog archive

### DIFF
--- a/blog.md
+++ b/blog.md
@@ -10,8 +10,9 @@ title: Blog archive
     	{% unless forloop.first %}</ul>{% endunless %}
     		<h5>{{ currentyear }}</h5>
     		<ul class="posts">
-    		{% capture year %}{{currentyear}}{% endcapture %} 
+    		{% capture year %}{{currentyear}}{% endcapture %}
   		{% endif %}
     <li><a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></li>
+    {% if forloop.last %}</ul>{% endif %}
 {% endfor %}
 </div>


### PR DESCRIPTION
When we have blog posts across multiple years, then, for the first year if we have more than one blog posts, there is rogue `</div>` tag which does not get rendered properly.

Reason: For the last loop iteration, the code never goes back to the

```
{% unless forloop.first %}</ul>{% endunless %}
```

which is responsible for closing the `ul` tag. As a reason, the generator is not able to render the close div tag properly.

Screenshot from live blog - 

**Before fix**

![image](https://cloud.githubusercontent.com/assets/875186/23100336/84ecd336-f6b9-11e6-8f0d-d3adf2ae9c1e.png)

**After fix**

![image](https://cloud.githubusercontent.com/assets/875186/23100387/74a21d14-f6ba-11e6-9a6f-3f43c954b5f2.png)

