### PR TITLE
Add configurable canonical support

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,16 +4,20 @@
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>{% if page.title %}{{ page.title }}{% else %}{{ site.harmony.name }}{% endif %}</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1">        
-        <meta name="description" content="{% if page.meta_description %}{{ page.meta_description }}{% else %}{{ site.harmony.meta_description }}{% endif %}">
-        <link rel="canonical" 
-        href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-        
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="description" content="{% if page.meta_description %}{{ page.meta_description }}{% else %}{{ site.harmony.meta_description }}{% endif %}">        
+        {% if page.canonical_url %}
+          {% assign canonical_url = page.canonical_url %}
+        {% else %}
+          {% assign canonical_url = (page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url) %}
+        {% endif %}
+        <link rel="canonical" href="{{ canonical_url }}" />
+
         <!-- Harmony styles -->
         <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/css/main.css">
 
         <!-- Modernizr js -->
-        <script async src="{{ site.baseurl }}/assets/js/modernizr.js"></script>    
+        <script async src="{{ site.baseurl }}/assets/js/modernizr.js"></script>
 
         <!-- IE Fixes -->
         <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -21,21 +25,21 @@
         <!--[if lt IE 9]>
           <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
           <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
-        <![endif]-->        
+        <![endif]-->
     </head>
     <body class="{{ site.harmony.basetheme }}">
         <header class="main-header">
             <div class="wc-container">
                 <h1><a href="{{ site.baseurl }}/">{{ site.harmony.name }}</a></h1>
                 <h2>{{ site.harmony.description }}</h2>
-                {% include header-links.html %}                
+                {% include header-links.html %}
             </div>
         </header>
         {{ content }}
         <footer class="main-footer">
             <div class="wc-container">
                 <div class="column one">
-                    {% include footer-links.html %}                    
+                    {% include footer-links.html %}
                 </div>
                 <div class="column two">
                     {% include social.html %}
@@ -65,5 +69,5 @@
         <script src="{{ site.baseurl }}/assets/js/all.js"></script>
         <!-- Google analytics  -->
         {% include google-analytics.html %}
-    </body>        
+    </body>
 </html>


### PR DESCRIPTION
Add support for a canonical tag for supporting articles to be published on multiple blogs. With the same article published on multiple systems, having a canonical tag lets Google know the original source of the article and so it does not penalize the blog.