### PR TITLE
Remove errant parenthesis to fix liquid syntax error

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -7,7 +7,7 @@ layout: default
 	<div class="post">
 		<h1>{{ page.title }}</h1>
 		<p class="post-meta">
-			{% if (page.categories.size > 0 %}
+			{% if page.categories.size > 0 %}
       <span class="categories">
       {{ page.categories | array_to_sentence_string }}
       </span> |

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ layout: default
     			</h3>
 
           <p class="post-meta">
-            {% if (post.categories.size > 0 %}
+            {% if post.categories.size > 0 %}
             <span class="categories">
             {{ post.categories | array_to_sentence_string }}
             </span> |


### PR DESCRIPTION
Small Liquid syntax error was causing warnings as seen in issue #22 
Removing the errant parenthesis fixes this.